### PR TITLE
close #3 Dev Containers 環境でのコンパイルをできるようにする

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "KatLab Seminar Report LaTeX Environment",
+  "dockerComposeFile": ["../compose.yaml"],
+  "service": "latex",
+  "workspaceFolder": "/workspace",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "James-Yu.latex-workshop"
+      ]
+    }
+  }
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,19 @@ RUN apt-get update && \
     make \
     inotify-tools \
     procps \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    locales && \
+    # ロケールの生成と設定
+    sed -i -E 's/# (ja_JP.UTF-8)/\1/' /etc/locale.gen && \
+    locale-gen && \
+    # ロケールの設定
+    update-locale LANG=ja_JP.UTF-8 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# ロケール設定
+ENV LANG=ja_JP.UTF-8
+ENV LANGUAGE=ja_JP:ja
+ENV LC_ALL=ja_JP.UTF-8
 
 # 作業ディレクトリの設定
 WORKDIR /workspace

--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,15 @@ LATEX_CLEAN = $(DOCKER_PREFIX) latexmk -c
 LATEX_CLEAN_ALL = $(DOCKER_PREFIX) latexmk -C
 CP_CMD = $(DOCKER_PREFIX) cp
 RM_CMD = $(DOCKER_PREFIX) rm -rf
-WATCH_CMD = $(DOCKER_PREFIX) $(CD_PREFIX) while true; do \
-    changed_file=$$(inotifywait -e close_write,create --format "%w%f" src/*.tex); \
-    if [ -f "$$changed_file" ]; then \
-        echo "Compiling: $$changed_file"; \
-        TEXINPUTS=./src//: latexmk -pdfdvi "$$changed_file" && \
-        cp build/$$(basename "$$changed_file" .tex).pdf pdf/; \
-    fi; \
-done$(if $(DOCKER_PREFIX),',"")
+WATCH_CMD = $(DOCKER_PREFIX) $(CD_PREFIX) \
+    while true; do \
+        changed_file=$$(inotifywait -e close_write,create --format "%w%f" src/*.tex); \
+        if [ -f "$$changed_file" ]; then \
+            echo "Compiling: $$changed_file"; \
+            TEXINPUTS=./src//: latexmk -pdfdvi "$$changed_file" && \
+            cp build/$$(basename "$$changed_file" .tex).pdf pdf/; \
+        fi; \
+    done$(if $(DOCKER_PREFIX),";",)
 LATEX_SINGLE = $(LATEX_CMD)
 
 # デフォルトターゲット
@@ -70,7 +71,7 @@ copy: ## 最新の .tex ファイルをコピーして日付を更新
 			echo "[ERROR] No tex files found in src/"; \
 			exit 1; \
 		fi; \
-		cat "$$latest_tex" | sed -e "s/^\\\date{.*}/\\\date{$$(LC_TIME=C TZ=Asia/Tokyo date '+%Y-%m-%d %a')}/g" > "$${FILE_NAME}"; \
+		cat "$$latest_tex" | sed -e "s/^\\\date{.*}/\\\date{$$(LANG=C LC_ALL=C TZ=Asia/Tokyo date '+%Y-%m-%d %a')}/g" > "$${FILE_NAME}"; \
 		echo "CREATED: $${FILE_NAME}"; \
 		$(LATEX_SINGLE) src/$${FILE_BASENAME} && \
 		$(CP_CMD) build/$$(basename $${FILE_BASENAME} .tex).pdf pdf/; \

--- a/Makefile
+++ b/Makefile
@@ -15,24 +15,26 @@ ifeq ($(IN_DEVCONTAINER),1)
 else
     # Docker Compose 経由での実行コマンド
     DOCKER_PREFIX = docker compose exec -T latex
-    CD_PREFIX = bash -c "cd /workspace &&
+    CD_PREFIX = bash -c cd /workspace &&
 endif
 
 # 共通のコマンドを定義
-LATEX_CMD = $(CD_PREFIX) TEXINPUTS=./src//: latexmk -pdfdvi
-LATEX_CLEAN = $(DOCKER_PREFIX) latexmk -c
-LATEX_CLEAN_ALL = $(DOCKER_PREFIX) latexmk -C
-CP_CMD = $(DOCKER_PREFIX) cp
-RM_CMD = $(DOCKER_PREFIX) rm -rf
-WATCH_CMD = $(DOCKER_PREFIX) $(CD_PREFIX) \
-	while true; do \
-		changed_file=$$(inotifywait -e close_write,create --format "%w%f" src/*.tex); \
-		if [ -f "$$changed_file" ]; then \
-			echo "Compiling: $$changed_file"; \
-			TEXINPUTS=./src//: latexmk -pdfdvi "$$changed_file" && \
-			cp build/$$(basename "$$changed_file" .tex).pdf pdf/; \
-		fi; \
-	done$(if $(DOCKER_PREFIX),";",)
+LATEX_CMD = $(DOCKER_PREFIX) $(CD_PREFIX) TEXINPUTS=./src//: latexmk -pdfdvi
+LATEX_CLEAN = $(DOCKER_PREFIX) $(CD_PREFIX) latexmk -c
+LATEX_CLEAN_ALL = $(DOCKER_PREFIX) $(CD_PREFIX) latexmk -C
+CP_CMD = $(DOCKER_PREFIX) $(CD_PREFIX) cp
+RM_CMD = $(DOCKER_PREFIX) $(CD_PREFIX) rm -rf
+WATCH_CMD = $(DOCKER_PREFIX) bash -c '\
+    cd /workspace && \
+    while true; do \
+        changed_file=$$(inotifywait -e close_write,create --format "%w%f" src/*.tex); \
+        if [ -f "$$changed_file" ]; then \
+            echo "Compiling: $$changed_file"; \
+            TEXINPUTS=./src//: latexmk -pdfdvi "$$changed_file" && \
+            cp build/$$(basename "$$changed_file" .tex).pdf pdf/; \
+        fi; \
+    done \
+'
 LATEX_SINGLE = $(LATEX_CMD)
 
 # デフォルトターゲット

--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,14 @@ LATEX_CLEAN_ALL = $(DOCKER_PREFIX) latexmk -C
 CP_CMD = $(DOCKER_PREFIX) cp
 RM_CMD = $(DOCKER_PREFIX) rm -rf
 WATCH_CMD = $(DOCKER_PREFIX) $(CD_PREFIX) \
-    while true; do \
-        changed_file=$$(inotifywait -e close_write,create --format "%w%f" src/*.tex); \
-        if [ -f "$$changed_file" ]; then \
-            echo "Compiling: $$changed_file"; \
-            TEXINPUTS=./src//: latexmk -pdfdvi "$$changed_file" && \
-            cp build/$$(basename "$$changed_file" .tex).pdf pdf/; \
-        fi; \
-    done$(if $(DOCKER_PREFIX),";",)
+	while true; do \
+		changed_file=$$(inotifywait -e close_write,create --format "%w%f" src/*.tex); \
+		if [ -f "$$changed_file" ]; then \
+			echo "Compiling: $$changed_file"; \
+			TEXINPUTS=./src//: latexmk -pdfdvi "$$changed_file" && \
+			cp build/$$(basename "$$changed_file" .tex).pdf pdf/; \
+		fi; \
+	done$(if $(DOCKER_PREFIX),";",)
 LATEX_SINGLE = $(LATEX_CMD)
 
 # デフォルトターゲット
@@ -95,41 +95,72 @@ clean-all: ## すべての LaTeX 生成ファイルを削除
 	done
 	$(RM_CMD) pdf/* build/*
 
+# Docker 関連コマンド実行時の実行環境チェック
+# devcontainer 下で docker コマンドを実行できないので、その場合は警告文を表示して終了する
+check_docker_cmd = @if [ "$(IN_DEVCONTAINER)" = "1" ]; then \
+	echo "[ERROR] Dev Container 環境では Docker 関連コマンドは使用できません"; \
+	exit 1; \
+fi
+
 # Docker 関連コマンド
 build: ## Docker イメージをビルド
+	$(check_docker_cmd)
 	docker compose build
 
 up: ## コンテナを起動（バックグラウンド）
+	$(check_docker_cmd)
 	docker compose up -d
 
 down: ## コンテナを停止・削除
+	$(check_docker_cmd)
 	docker compose down
 
 exec: ## コンテナに接続
+	$(check_docker_cmd)
 	docker compose exec latex bash
 
 stop: ## コンテナを停止
+	$(check_docker_cmd)
 	docker compose stop
 
 logs: ## コンテナのログを表示
+	$(check_docker_cmd)
 	docker compose logs -f latex
 
 # 開発用コマンド
-setup: build up ## 初回セットアップ (ビルド + 起動)
-	@echo "環境が準備できました。以下のコマンドでコンパイルできます:"
-	@echo "  make compile  # src 下の .tex ファイルをコンパイル"
-	@echo "  make watch sample.tex    # 指定ファイルの変更を監視してコンパイル"
+setup: ## 初回セットアップ (ビルド + 起動)
+	@if [ "$(IN_DEVCONTAINER)" = "1" ]; then \
+		echo "[INFO] Dev Container 環境では make setup による初回セットアップは不要です。"; \
+		echo "以下のコマンドでコンパイルできます:"; \
+		echo "  make compile  # src 下の .tex ファイルをコンパイル"; \
+		echo "  make watch   # ファイルの変更を監視してコンパイル"; \
+	else \
+		make build up; \
+		echo "環境構築を完了しました。以下のコマンドでコンパイルできます:"; \
+		echo "  make compile  # src 下の .tex ファイルをコンパイル"; \
+		echo "  make watch   # ファイルの変更を監視してコンパイル"; \
+	fi
 
-dev: up watch ## 開発モード (起動 + 監視コンパイル)
+dev: ## 開発モード (起動 + 監視コンパイル)
+	@if [ "$(IN_DEVCONTAINER)" = "1" ]; then \
+		echo "[WARNING] Dev Container 環境では make up は不要です。make watch を実行します"; \
+		make watch; \
+	else \
+		make up watch; \
+	fi
 
-restart: down up ## コンテナを再起動
+restart: ## コンテナを再起動
+	$(check_docker_cmd)
+	@make down up
 
-rebuild: down build up ## 完全に再ビルド
+rebuild: ## 完全に再ビルド
+	$(check_docker_cmd)
+	@make down build up
 
 # ファイル操作
 open-pdf: ## 生成されたPDFを開く（Mac用）
 	@if [ -f build/sample.pdf ]; then \
 		open build/sample.pdf; \
 	else \
-		echo "PDFファイルが見つかりません。先にmake compileを実行してください。"; \
+		echo "PDFファイルが見つかりません。先に make compile を実行してください。"; \
 	fi

--- a/README.md
+++ b/README.md
@@ -22,12 +22,43 @@ make copy
 
 ## 環境構築
 
-### Docker コンテナのビルドと起動
+## 環境構築方法
+
+### 1. Makefile を使用した環境構築
+
+`make` コマンドが利用可能な環境では、以下の手順で環境を構築できます：
 
 ```bash
-# 初回セットアップ
+# 初回セットアップ (Docker イメージのビルドと起動)
 make setup
+
+# src/ 下のすべての .tex ファイルを強制的に再コンパイル
+make compile
+
+# src/ 下のすべての .tex ファイルを監視し、変更があったら自動コンパイル、PDF 出力
+make watch
 ```
+
+生成された PDF ファイルは `pdf/` ディレクトリに出力される。
+
+### 2. Dev Containers を使用した環境構築
+
+VS Code の Dev Containers を使用して環境を構築することもできる：
+
+1. VS Code に [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) 拡張機能をインストールする。
+2. このリポジトリを VS Code で開く。
+3. コマンドパレット（`Cmd + Shift + P または Ctrl + Shift + P`）を開き、`Dev Containers: Rebuild and Reopen in Container` を選択する。もしくは、GUI 左下の青い >< から、`コンテナーで再度開く` を選択する。
+4. コンテナ内で以下のコマンドを使用して作業を進める：
+
+```bash
+# src/ 下のすべての .tex ファイルを強制的に再コンパイル
+make compile
+
+# src/ 下のすべての .tex ファイルを監視し、変更があったら自動コンパイル、PDF 出力
+make watch
+```
+
+Dev Container 環境下では Docker 関連のコマンドの操作は不要。
 
 ## LaTeX 文書の作成とコンパイル
 
@@ -55,23 +86,32 @@ make watch
 
 ## 利用可能なMakeコマンド
 
-| コマンド | 説明 |
-|---------|------|
-| `make help` | 利用可能なコマンド一覧を表示 |
-| `make setup` | 初回セットアップ（ビルド + 起動） |
-| `make build` | Docker イメージをビルド |
-| `make up` | コンテナを起動 |
-| `make down` | コンテナを停止・削除 |
-| `make exec` | コンテナに接続 |
-| `make compile` | src/ 下の TeX ファイルをコンパイル |
-| `make watch` | ファイルの変更を監視してコンパイル |
-| `make copy` | 今日の日付で新しい .tex ファイルを作成。変更を監視し、自動コンパイル |
-| `make clean` | LaTeX 中間ファイルを削除 |
-| `make clean-all` | すべての LaTeX 生成ファイルを削除 |
-| `make open-pdf` | 生成された PDF を開く (Mac用) |
-| `make restart` | コンテナを再起動 |
-| `make rebuild` | 完全に再ビルド |
-| `make dev` | 開発モード（起動 + 監視コンパイル） |
+### LaTeX 関連コマンド
+
+| コマンド         | 説明                                                                 |
+|------------------|----------------------------------------------------------------------|
+| `make help`      | 利用可能なコマンド一覧を表示                                         |
+| `make compile`   | `src` 下の TeX ファイルを強制再コンパイル                                 |
+| `make watch`     | ファイルの変更を監視してコンパイル                                   |
+| `make copy`      | 今日の日付で新しい `.tex` ファイルを作成。変更を監視し、自動コンパイル |
+| `make clean`     | LaTeX 中間ファイルを削除                                             |
+| `make clean-all` | すべての LaTeX 生成ファイルを削除                                     |
+| `make open-pdf`  | 生成された PDF を開く (Mac用)                                        |
+
+### Docker 関連コマンド
+
+| コマンド         | 説明                                                                 |
+|------------------|----------------------------------------------------------------------|
+| `make setup`     | 初回セットアップ（ビルド + 起動）                                    |
+| `make build`     | Docker イメージをビルド                                             |
+| `make up`        | コンテナを起動                                                      |
+| `make down`      | コンテナを停止・削除                                                |
+| `make exec`      | コンテナに接続                                                     |
+| `make stop`      | コンテナを停止                                                     |
+| `make logs`      | コンテナのログを表示                                               |
+| `make restart`   | コンテナを再起動                                                   |
+| `make rebuild`   | 完全に再ビルド                                                     |
+| `make dev`       | 開発モード（起動 + 監視コンパイル）
 
 ## ディレクトリ構成
 
@@ -106,7 +146,7 @@ make clean-all  # すべての生成ファイルを削除
 make compile    # 再コンパイル
 ```
 
-3. Docker環境の再構築
+3. Docker 環境の再構築
 ```bash
 make rebuild    # コンテナの完全な再構築
 ```


### PR DESCRIPTION
make 環境がない場合、`make setup` による初回セットアップができなかった。
そのため、Dev Container で Docker コンテナ内で動作できるようにした。

これにより、Dockerfile で make パッケージをインストールするようにしているため、各 `make` コマンドが実行できるようになる。
`make build` など、一部の docker コマンドを用いる `make` コマンドは、Dev Container 環境では実行できない。
そのため、docker コマンドを用いる `make` コマンドを実行した場合は、そのコマンドが実行できない・実行不要であることを示すメッセージを表示する。