### PR TITLE
close #5 make watch 実行中にファイル保存をしても PDF が再生成されない問題の修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,17 +24,19 @@ LATEX_CLEAN = $(DOCKER_PREFIX) $(CD_PREFIX) latexmk -c
 LATEX_CLEAN_ALL = $(DOCKER_PREFIX) $(CD_PREFIX) latexmk -C
 CP_CMD = $(DOCKER_PREFIX) $(CD_PREFIX) cp
 RM_CMD = $(DOCKER_PREFIX) $(CD_PREFIX) rm -rf
-WATCH_CMD = $(DOCKER_PREFIX) bash -c '\
-    cd /workspace && \
+WATCH_CMD = $(DOCKER_PREFIX) bash -c 'cd /workspace && \
     while true; do \
-        changed_file=$$(inotifywait -e close_write,create --format "%w%f" src/*.tex); \
-        if [ -f "$$changed_file" ]; then \
-            echo "Compiling: $$changed_file"; \
-            TEXINPUTS=./src//: latexmk -pdfdvi "$$changed_file" && \
-            cp build/$$(basename "$$changed_file" .tex).pdf pdf/; \
-        fi; \
-    done \
-'
+        inotifywait -r -e modify,create,delete src/*.tex; \
+        echo "Changes detected, recompiling..."; \
+        for tex in src/*.tex; do \
+            if [ -f "$$tex" ]; then \
+                echo "Compiling: $$tex"; \
+                TEXINPUTS=./src//: latexmk -pdfdvi "$$tex" && \
+                mkdir -p pdf && \
+                cp build/$$(basename "$$tex" .tex).pdf pdf/ || echo "Failed to copy PDF for $$tex"; \
+            fi \
+        done; \
+    done'
 LATEX_SINGLE = $(LATEX_CMD)
 
 # デフォルトターゲット

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,8 @@ compile: ## src 下の .tex ファイルをコンパイル
 		$(LATEX_CMD) $$tex; \
 		$(CP_CMD) build/$$(basename $${tex%.tex}).pdf pdf/; \
 	done
+	@echo "コンパイル完了、ファイルの変更監視を開始"
+	@make watch
 
 watch: ## ファイル変更を監視してコンパイル
 	@mkdir -p pdf build

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,13 @@ LATEX_SINGLE = $(LATEX_CMD)
 
 # デフォルトターゲット
 all: $(PDF_FILES) ## すべての TeX ファイルを PDF に変換
+	@if [ -n "$(TEX_FILES)" ]; then \
+		echo "コンパイル完了。ファイルの変更監視を開始します..."; \
+		make watch; \
+	else \
+		echo "[WARNING] src/ ディレクトリに .tex ファイルが見つかりません。"; \
+		exit 1; \
+	fi
 
 help: ## ヘルプを表示
 	@echo "利用可能なコマンド:"

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 このリポジトリは、Docker を使用した KatLab のゼミ報告書執筆環境を提供するリポジトリである。
 
-## クイックスタート
+## 環境構築
 
-### Makefile を使用した make コマンド
+### 1. Makefile を使用した環境構築
+
+`make` コマンドが利用可能な環境では、すぐに以下の手順で環境を構築できる：
 
 ```bash
 # 初回セットアップ（Docker イメージのビルドと起動）
@@ -20,25 +22,6 @@ make copy
 
 `make copy` 実行後は、新規作成した .tex ファイルの変更を監視する。
 
-## 環境構築
-
-## 環境構築方法
-
-### 1. Makefile を使用した環境構築
-
-`make` コマンドが利用可能な環境では、以下の手順で環境を構築できます：
-
-```bash
-# 初回セットアップ (Docker イメージのビルドと起動)
-make setup
-
-# src/ 下のすべての .tex ファイルを強制的に再コンパイル
-make compile
-
-# src/ 下のすべての .tex ファイルを監視し、変更があったら自動コンパイル、PDF 出力
-make watch
-```
-
 生成された PDF ファイルは `pdf/` ディレクトリに出力される。
 
 ### 2. Dev Containers を使用した環境構築
@@ -47,18 +30,25 @@ VS Code の Dev Containers を使用して環境を構築することもでき�
 
 1. VS Code に [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) 拡張機能をインストールする。
 2. このリポジトリを VS Code で開く。
-3. コマンドパレット（`Cmd + Shift + P または Ctrl + Shift + P`）を開き、`Dev Containers: Rebuild and Reopen in Container` を選択する。もしくは、GUI 左下の青い >< から、`コンテナーで再度開く` を選択する。
+3. コマンドパレット（`Cmd + Shift + P または Ctrl + Shift + P`）を開き、`Dev Containers: Rebuild and Reopen in Container` を選択する。もしくは、GUI 左下の青い >< から、`コンテナーで再度開く` -> `ワークスペースに構成を追加する` -> `` `Dockerfile` から`` -> 青い OK ボタン -> 青い OK ボタン の順で選択する。
 4. コンテナ内で以下のコマンドを使用して作業を進める：
 
+これにより、Docker コンテナ内で `make` を実行可能となり、以下の手順で環境を構築できる：
+
 ```bash
-# src/ 下のすべての .tex ファイルを強制的に再コンパイル
-make compile
+# src 下の .tex ファイルをコンパイルし、PDF に変換
+make
 
-# src/ 下のすべての .tex ファイルを監視し、変更があったら自動コンパイル、PDF 出力
-make watch
+# 最新の .tex ファイルの内容をコピーし、現在の日付で新規 .tex ファイルを作成
+# 変更を自動監視し、変更後の内容で PDF を再生成
+make copy
 ```
-
 Dev Container 環境下では Docker 関連のコマンドの操作は不要。
+
+`make copy` 実行後は、新規作成した .tex ファイルの変更を監視する。
+
+生成された PDF ファイルは `pdf/` ディレクトリに出力される。
+
 
 ## LaTeX 文書の作成とコンパイル
 
@@ -88,30 +78,30 @@ make watch
 
 ### LaTeX 関連コマンド
 
-| コマンド         | 説明                                                                 |
-|------------------|----------------------------------------------------------------------|
-| `make help`      | 利用可能なコマンド一覧を表示                                         |
-| `make compile`   | `src` 下の TeX ファイルを強制再コンパイル                                 |
-| `make watch`     | ファイルの変更を監視してコンパイル                                   |
+| コマンド          | 説明                                                         |
+|------------------|-------------------------------------------------------------|
+| `make help`      | 利用可能なコマンド一覧を表示 |
+| `make compile`   | `src` 下の TeX ファイルを強制再コンパイル |
+| `make watch`     | ファイルの変更を監視してコンパイル |
 | `make copy`      | 今日の日付で新しい `.tex` ファイルを作成。変更を監視し、自動コンパイル |
-| `make clean`     | LaTeX 中間ファイルを削除                                             |
-| `make clean-all` | すべての LaTeX 生成ファイルを削除                                     |
-| `make open-pdf`  | 生成された PDF を開く (Mac用)                                        |
+| `make clean`     | LaTeX 中間ファイルを削除 |
+| `make clean-all` | すべての LaTeX 生成ファイルを削除 |
+| `make open-pdf`  | 生成された PDF を開く (Mac用) |
 
 ### Docker 関連コマンド
 
-| コマンド         | 説明                                                                 |
-|------------------|----------------------------------------------------------------------|
-| `make setup`     | 初回セットアップ（ビルド + 起動）                                    |
-| `make build`     | Docker イメージをビルド                                             |
-| `make up`        | コンテナを起動                                                      |
-| `make down`      | コンテナを停止・削除                                                |
-| `make exec`      | コンテナに接続                                                     |
-| `make stop`      | コンテナを停止                                                     |
-| `make logs`      | コンテナのログを表示                                               |
-| `make restart`   | コンテナを再起動                                                   |
-| `make rebuild`   | 完全に再ビルド                                                     |
-| `make dev`       | 開発モード（起動 + 監視コンパイル）
+| コマンド          | 説明                          |
+|------------------|------------------------------|
+| `make setup`     | 初回セットアップ (ビルド + 起動) |
+| `make build`     | Docker イメージをビルド |
+| `make up`        | コンテナを起動 |
+| `make down`      | コンテナを停止・削除 |
+| `make exec`      | コンテナに接続 |
+| `make stop`      | コンテナを停止 |
+| `make logs`      | コンテナのログを表示 |
+| `make restart`   | コンテナを再起動 |
+| `make rebuild`   | 完全に再ビルド |
+| `make dev`       | 開発モード (起動 + 監視コンパイル) |
 
 ## ディレクトリ構成
 
@@ -150,3 +140,22 @@ make compile    # 再コンパイル
 ```bash
 make rebuild    # コンテナの完全な再構築
 ```
+
+4. service "latex" is not running の対処
+
+```bash
+service "latex" is not running
+make: *** [watch] Error 1
+```
+
+**原因**
+Docker compose 環境で動作しようとしているものの、コンテナが起動していない
+
+**解決策**
+以下のコマンドでコンテナを起動する。
+
+```bash
+make up
+```
+
+そもそもビルドをしていない、初回設定をしていない場合は、`make setup` や `make build`


### PR DESCRIPTION
# 概要
make watch 実行中にもかかわらず、.tex ファイルに変更を加えて保存をしても、PDF が再生成されない問題を修正。

さらに、 make コマンドと make compile 実行時、自動で make watch コマンドを実行するように。
これにより、make watch を打たなくとも、コンパイル系のコマンドを実行すると、自動でファイル変更を監視できるようになる。

# 環境 (Dev Container or Docker compose)

- [x] Dev Container
- [x] Docker compose
